### PR TITLE
Weather api change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ To support [HACS](https://community.home-assistant.io/t/custom-component-hacs/12
 - sinope-gt125 for devices management via direct conection to the gt125 web gateway
 - sinope-1 for devices management via [Neviweb](http://neviweb.com) portal.
 
+As a replacement for Dark Sky api, I've added support for Open Weather Map api
+
 If you already use this custom_component, make a backup of your file devices.json before first update via HACS. Devices.json will be removed. You'll need to copy your devices data to config/.storage/sinope_devices.json after first run of device.py (see below).
 # Hassbian vs Hass.io
 Those two HA platform use different location for  configuration. Now we have updated Sinope-GT125 so it can detect which platform you are using and adjust config location automatically.
@@ -82,7 +84,8 @@ sinope:
   server: '<Ip adress of your GT125>'
   id: '<ID written on the back of your GT125>' non space
   api_key: '<Api_key received on first manual connection with the GT125>' #run device.py for that
-  dk_key: '<your Dark sky key>'
+  dk_key: '<your Dark sky key>' or 'your Open weather map key'
+  my_weather: 'dark' for Dark sky api or 'owm' for Open weather map api
   my_city: '<the nearest city>' #needed to get sunrise and sunset hours for your location.
   scan_interval: 120 #you can go down to 60 if you want depending on how many devices you have to update. Default set to 180
   ```

--- a/custom_components/sinope/__init__.py
+++ b/custom_components/sinope/__init__.py
@@ -293,7 +293,7 @@ def get_outside_temperature(key, latitude, longitude, my_weather):
         ledata =r.json()
         return to_celcius(float(json.dumps(ledata["currently"]["temperature"])),"C")
     else:  # https://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&appid={your api key} 
-        r = requests.get('https://api.openweathermap.org/data/2.5/weather?lat={'+latitude+'}&lon={'longitude+'}&appid={'+key+'}') 
+        r = requests.get('https://api.openweathermap.org/data/2.5/weather?lat={'+latitude+'}&lon={'+longitude+'}&appid={'+key+'}') 
         ledata =r.json()
         return to_celcius(float(json.dumps(ledata["main"]["temp"])),"K")
     

--- a/custom_components/sinope/__init__.py
+++ b/custom_components/sinope/__init__.py
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_SERVER): cv.string,
         vol.Required(CONF_DK_KEY): cv.string,
         vol.Optional(CONF_MY_WEATHER, default=MY_WEATHER): cv.string,
-	vol.Optional(CONF_MY_CITY, default=MY_CITY): cv.string,
+        vol.Optional(CONF_MY_CITY, default=MY_CITY): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
             cv.time_period
     })

--- a/custom_components/sinope/__init__.py
+++ b/custom_components/sinope/__init__.py
@@ -286,7 +286,7 @@ def to_celcius(temp,unit): #unit = K for kelvin, C for celcius, F for farenheigh
 
 def from_celcius(temp):
     return round((temp+1.8)+32, 2)
-  
+
 def get_outside_temperature(key, latitude, longitude, my_weather): 
     if my_weather == 'dark': # https://api.darksky.net/forecast/{your dark sky key}/{latitude},{logitude}
         r = requests.get('https://api.darksky.net/forecast/'+key+'/'+latitude+','+longitude+'?exclude=minutely,hourly,daily,alerts,flags')

--- a/custom_components/sinope/__init__.py
+++ b/custom_components/sinope/__init__.py
@@ -28,12 +28,14 @@ DATA_DOMAIN = 'data_' + DOMAIN
 CONF_SERVER = 'server'
 CONF_DK_KEY = 'dk_key'
 CONF_MY_CITY = 'my_city'
+CONF_MY_WEATHER = 'my_weather'
 
 _LOGGER = logging.getLogger(__name__)
 
 #default values
 SCAN_INTERVAL = timedelta(seconds=180)
-MY_CITY = 'Montreal' 
+MY_CITY = 'Montreal'
+MY_WEATHER = 'dark' # put 'dark' if you still use Dark Sky weather data, 'owm' is for Openweathermap
 
 REQUESTS_TIMEOUT = 30
 
@@ -43,6 +45,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_ID): cv.string,
         vol.Required(CONF_SERVER): cv.string,
         vol.Required(CONF_DK_KEY): cv.string,
+        vol.Optional(CONF_MY_WEATHER, default=MY_WEATHER): cv.string,
 	vol.Optional(CONF_MY_CITY, default=MY_CITY): cv.string,
         vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
             cv.time_period
@@ -81,11 +84,12 @@ class SinopeData:
         api_id = config.get(CONF_ID)
         server = config.get(CONF_SERVER)
         dk_key = config.get(CONF_DK_KEY)
+        my_weather = config.get(CONF_MY_WEATHER)
         my_city = config.get(CONF_MY_CITY)
         tz = config.get(CONF_TIME_ZONE)
         latitude = config.get(CONF_LATITUDE)
         longitude = config.get(CONF_LONGITUDE)
-        self.sinope_client = SinopeClient(api_key, api_id, server, my_city, tz, latitude, longitude, dk_key)
+        self.sinope_client = SinopeClient(api_key, api_id, server, my_city, tz, latitude, longitude, dk_key, my_weather)
 
     # Need some refactoring here concerning the class used to transport data
     # @Throttle(SCAN_INTERVAL)
@@ -274,16 +278,24 @@ def get_temperature(data):
         else:  
             return round(float.fromhex(latemp)*0.01, 2)
   
-def to_celcius(temp):
-    return round((temp-32)*0.5555, 2)
+def to_celcius(temp,unit): #unit = K for kelvin, C for celcius, F for farenheight
+    if unit == "C":
+        return round((temp-32)*0.5555, 2)
+    else:
+        return round((temp-273.15),2)
 
 def from_celcius(temp):
     return round((temp+1.8)+32, 2)
   
-def get_outside_temperature(key, latitude, longitude): #https://api.darksky.net/forecast/{your dark sky key}/{latitude},{logitude}
-    r = requests.get('https://api.darksky.net/forecast/'+key+'/'+latitude+','+longitude+'?exclude=minutely,hourly,daily,alerts,flags')
-    ledata =r.json()
-    return to_celcius(float(json.dumps(ledata["currently"]["temperature"])))
+def get_outside_temperature(key, latitude, longitude, my_weather): 
+    if my_weather == 'dark': # https://api.darksky.net/forecast/{your dark sky key}/{latitude},{logitude}
+        r = requests.get('https://api.darksky.net/forecast/'+key+'/'+latitude+','+longitude+'?exclude=minutely,hourly,daily,alerts,flags')
+        ledata =r.json()
+        return to_celcius(float(json.dumps(ledata["currently"]["temperature"])),"C")
+    else:  # https://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&appid={your api key} 
+        r = requests.get('https://api.openweathermap.org/data/2.5/weather?lat={'+latitude+'}&lon={'longitude+'}&appid={'+key+'}') 
+        ledata =r.json()
+        return to_celcius(float(json.dumps(ledata["main"]["temp"])),"K")
     
 def set_away(away): #0=home,2=away
     return "01"+bytearray(struct.pack('<i', away)[:1]).hex()
@@ -752,7 +764,7 @@ class SinopeClient(object):
     def set_hourly_report(self):
         """we need to send temperature once per hour if we want it to be displayed on second thermostat display line"""
         try:
-            result = get_result(bytearray(send_request(self, data_report_request(data_report_command,all_unit,data_outdoor_temperature,set_temperature(get_outside_temperature(self._dk_key, self._latitude, self._longitude))))).hex())
+            result = get_result(bytearray(send_request(self, data_report_request(data_report_command,all_unit,data_outdoor_temperature,set_temperature(get_outside_temperature(self._dk_key, self._latitude, self._longitude, self._my_weather))))).hex())
         except OSError:
             raise PySinopeError("Cannot send temperature report to each devices")
         return result


### PR DESCRIPTION
As Dark sky is going out and no new account can be created, I've added a new weather api from Open Weather Map.  
A new parameter is added to Sinope, my_weather, so you can choose from Dark sky  and Open Weather Map. 
```
my_weather: 'owm' 
or
my_weather: 'dark'
```
You can still use Dark sky or switch to Open Weather Map as you wish.